### PR TITLE
Add support for osu!plus's "Recent 24h" section (fixes conflict between two scripts)

### DIFF
--- a/osu.user.js
+++ b/osu.user.js
@@ -1147,7 +1147,8 @@ const TopRanksWorker = (userId, modestr, addedNodes = [document.body]) => {
     addedNodes.forEach((eles) => {
         if(eles instanceof Element) eles.querySelectorAll(":scope div.play-detail.play-detail--highlightable").forEach((ele) => {
             if(ele.getAttribute("improved") !== null) return;
-            const a = ele.querySelector(":scope time.js-timeago");
+            let a = ele.querySelector(":scope time.js-timeago");
+            if(a === null) a = ele.querySelector(":scope time.timeago")
             const t = a.getAttribute("datetime");
             const data = messageCache.get(`${userId},${modestr},${subdomain},${t}`);
             if(data){


### PR DESCRIPTION
Hi! I recently added the osu!web enhancement userscript and I liked the way the beatmap backgrounds were embedded behind each top score element, but it didn't work for any scores shown after pressing the "Show More" buttons. Looking into it for a bit, I found that basically the way the "Recent 24h" section of the osu!plus userscript that I also had installed was organized had the class for the `time` element as `timeago` instead of `js-timeago`, which I assume was default for the rest of `time` elements elsewhere in the user page, so whenever it wouldn't find `js-timeago`, `a` would just become null and the subsequent call asking for the `datetime` attribute of `a` would just throw a null type error. So I just added a check that would see if `a` was null when calling for a time element with the `js-timeago` class and made it call for a `time` element that just had the `timeago` class and it fixed the issue. There's probably a better way to do this but I rarely mess with JS and DOM at the same time so I wasn't entirely sure how to do it. Feel free to implement this in a better way.

![image](https://github.com/user-attachments/assets/5abae99f-c9ec-4a78-ad94-7a1fd3da00ba)
*(example ss of this happening, added `console.log(ele)` for each instance to see what was different and causing the error)*
